### PR TITLE
Add RTD link and fix code-block in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,10 @@ Homestead-guide
 
 Homestead guide is the reference documentation accompanying the homestead release of the ethereum project.
 
+
+`Hosted on ReadTheDocs`_
+
+
 Roadmap for homestead guide
 ==============================
 
@@ -34,16 +38,16 @@ Directory structure
 =========================
 
 .. code-block::
-  homestead-guide
-    build    - workdir, not commited to repo
-    source   - actual content in rst
-      conf.py - sphinx configuration
-    frontier
-      wiki    - the legacy wiki
-      gitbook - the legacy gitbook resources (converted to rst)
-    make.bat - windows command to build docs
-    Makefile - platforms with make to build docs
+
+    homestead-guide
+      build    - workdir, not commited to repo
+      source   - actual content in rst
+        conf.py - sphinx configuration
+      frontier
+        wiki    - the legacy wiki
+        gitbook - the legacy gitbook resources (converted to rst)
+      make.bat - windows command to build docs
+      Makefile - platforms with make to build docs
 
 
-
-
+.. _Hosted on ReadTheDocs: https://ethereum-homestead.readthedocs.org/en/latest/


### PR DESCRIPTION
### What was wrong?

I wanted to link to the built documentation on but the link was nowhere to be found!

### How was it fixed

Added a link to the RTD site.

(also took the liberty of fixing the code block for the directory structure part.

#### Cute animal picture

![animal-sweater-2](https://cloud.githubusercontent.com/assets/824194/12661489/18383992-c5d7-11e5-844b-8000a55c27d4.jpg)
