### PR TITLE
Add alarm and computation market to baselayer services

### DIFF
--- a/source/ethereum-ecosystem/base-layer-services.rst
+++ b/source/ethereum-ecosystem/base-layer-services.rst
@@ -1,3 +1,34 @@
 ********************************************************************************
 Base Layer Services
 ********************************************************************************
+
+
+Ethereum Alarm Clock
+--------------------
+
+* **Author:** Piper Merriam
+* **Website:** `alarm_main_website`_.
+* **Documentation:** `alarm_documentation`_.
+
+A marketplace that facilitates scheduling transactions to occur at a later
+time.  Serves a similar role to things like *crontab* in unix, or *setTimeout*
+in javascript.
+
+
+Ethereum Computation Market
+---------------------------
+
+* **Author:** Piper Merriam
+* **Website:** `computation_market_main_website`_.
+* **Documentation:** `computation_market_documentation`_.
+
+A marketplace that facilitates verifiable execution of computations off-chain.
+Allows for very expernsive computations to be used within the EVM without
+having to actually pay the high gas costs of executing them on-chain.
+
+
+
+.. _alarm_main_website: http://www.ethereum-alarm-clock.com/
+.. _alarm_documentation: http://docs.ethereum-alarm-clock.com/
+.. _computation_market_main_website: http://www.ethereum-computation-market.com/
+.. _computation_market_documentation: http://docs.ethereum-computation-market.com/


### PR DESCRIPTION
Let me know if this is the wrong place for this.

This PR adds Alarm Clock and the Computation Market to the Base Layer Services section of the docs.

![cat-wearing-a-cabbage-leaf-hat](https://cloud.githubusercontent.com/assets/824194/12986238/64401ab2-d0b3-11e5-92dc-02dd4e87df04.jpg)

