### PR TITLE
setup travis-ci linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: false
+cache: pypi
+language: python
+python:
+  - "2.7"
+env:
+  matrix:
+    - TOX_ENV=rst_lint
+install:
+  - 'travis_retry pip install setuptools --upgrade'
+  - 'travis_retry pip install tox'
+script:
+  - tox -e $TOX_ENV
+after_script:
+  - cat .tox/$TOX_ENV/log/*.log

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+restructuredtext-lint==0.14.2

--- a/rst_lint.py
+++ b/rst_lint.py
@@ -1,0 +1,41 @@
+# Load in our dependencies
+import os
+import sys
+
+import restructuredtext_lint as rst_lint
+
+
+BASE_DIR = os.path.dirname(__file__)
+SOURCE_DIR = os.path.join(BASE_DIR, "source")
+
+
+def lint(dir=SOURCE_DIR):
+    errors = []
+
+    for root, subdirs, files in os.walk(SOURCE_DIR):
+        for filename in files:
+            extension = filename.rpartition('.')[2].lower()
+            if extension == "rst":
+                linting_errors = rst_lint.lint_file(os.path.join(root, filename))
+                if linting_errors:
+                    errors.extend(linting_errors)
+
+    if errors:
+        for error in errors:
+            message = "{full_file_path}:{line_no}: {message}\n".format(
+                full_file_path=os.path.relpath(error.source),
+                line_no=error.line,
+                message=error.message,
+            )
+            if error.type == "WARNING":
+                sys.stdout.write(message)
+            else:
+                sys.stderr.write(message)
+    if any(error.type == "ERROR" for error in errors):
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    lint()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+skipsdist=true
+envlist=
+    rst_lint
+
+[testenv]
+commands=py.test --tb native {posargs:tests}
+deps =
+    -r{toxinidir}/requirements.txt
+
+[testenv:rst_lint]
+basepython=python
+commands=python {toxinidir}/rst_lint.py


### PR DESCRIPTION
### What was wrong

#. It is nice to have a codebase be conformant to a code style, and the same is true for documentation.  Ideally all of the restructured text is written in a similar style.

#. Restructured text is semi-complex and sometime we get the syntax a little wrong.


### How was it fixed.

Using travis-ci, all files which end with `.rst` will be linted using the [restructuredtext_lint](https://github.com/twolfson/restructuredtext-lint) python library.

* linting via the `rst_lint.py` file which handles recursing over the files and outputting error messages.
* `tox` as a test harness via the `tox.ini` file
* Travic-Ci configuration using the `.travis.yml` file which delegates running the tests to tox.

#### Cute animal picture

![original_stripe-or-spot-dog-tie](https://cloud.githubusercontent.com/assets/824194/13418908/0d8e5a2a-df37-11e5-88e6-04cbf96c248f.jpg)

