### PR TITLE
note that Ether values are in wei

### DIFF
--- a/source/contracts-and-transactions/account-types-gas-and-transactions.rst
+++ b/source/contracts-and-transactions/account-types-gas-and-transactions.rst
@@ -24,7 +24,9 @@ Contract Accounts:
 - Can send messages.
 - Contracts are controlled by their contract code.
 - Only send transactions in response to other transactions that they have received. Therefore, all action on the Ethereum block chain is set in motion by transactions fired from externally owned accounts.
-- Every time a contract account receives a transaction it's code activates, allowing it to read and write to internal storage and send other transactions/messages or create contracts.
+- Every time a contract account receives a transaction its code activates, allowing it to read and write to internal storage and send other transactions/messages or create contracts.
+
+All Ether balances and values are denominated in units of wei: 1 Ether is 1e18 wei.
 
 Note that "contracts" in Ethereum should not be seen as something that should be "fulfilled" or "complied with"; rather, they are more like "autonomous agents" that live inside of the Ethereum execution environment, always executing a specific piece of code when "poked" by a message or transaction, and having direct control over their own ether balance and their own key/value store to keep track of persistent variables.
 
@@ -35,7 +37,7 @@ The term "transaction" is used in Ethereum to refer to the signed data package t
 Transactions contain:
  - The recipient of the message.
  - A signature identifying the sender.
- - ``VALUE`` field - The amount of ether to transfer from the sender to the recipient.
+ - ``VALUE`` field - The amount of wei to transfer from the sender to the recipient.
  - An optional data field.
  - A ``STARTGAS`` value, representing the maximum number of computational steps the transaction execution is allowed to take.
  - A ``GASPRICE`` value, representing the fee the sender pays per computational step.
@@ -47,7 +49,7 @@ Contracts have the ability to send "messages" to other contracts. Messages are v
 A message contains:
  - The sender of the message (implicit).
  - The recipient of the message.
- - ``VALUE`` field - The amount of ether to transfer alongside the message to the contract address.
+ - ``VALUE`` field - The amount of wei to transfer alongside the message to the contract address.
  - An optional data field.
  - A ``STARTGAS`` value.
 


### PR DESCRIPTION
The first 2 instances of Ether value have been replaced with wei; others have not, but a general note has been added at the top.