### PR TITLE
Cleanup formatting on devtools page

### DIFF
--- a/source/developing-on-ethereum/developer-tools.rst
+++ b/source/developing-on-ethereum/developer-tools.rst
@@ -4,19 +4,27 @@ Developer Tools
 As a Ðapp developer you have five main resources which allow Ðapp
 development.
 
+
 Five Primary Resources
 ================================================================================
-ÐApp development requires an understanding of the Web3 Javascript API, the JSON RPC API, and the Solidity programming language. Note: There are developer tools that help you develop, test, and deploy ÐApps in a way that automatically utilizes the resources listed below.
+ÐApp development requires an understanding of the Web3 Javascript API, the JSON RPC API, and the Solidity programming language. 
 
-.. todo::
+.. note:: There are developer tools that help you develop, test, and deploy ÐApps in a way that automatically utilizes the resources listed below.
 
-   Add cross reference to developer tools page in the first paragraph.
 
--  `Web3 JavaScript API <https://github.com/ethereum/wiki/wiki/JavaScript-API>`__ - This is the main JavaScript SDK to use when you want to interact with an Ethereum node.
--  `JSON RPC API <https://github.com/ethereum/wiki/wiki/JSON-RPC>`__ - This is the low level JSON RPC 2.0 interface to interface with a node. This API is used by the `Web3 JavaScript API <https://github.com/ethereum/wiki/wiki/JavaScript-API>`__.
--  `Solidity Documentation <https://solidity.readthedocs.org/en/latest/>`__ - Solidity is the Ethereum developed Smart Contract language, which compiles to EVM (Ethereum Virtual Machine) opcodes.
--  `Testnets`_ - Test networks help developers develop and test Ethereum code and network interactions without spending their own Ether on the main network. Test network options are listed below.
-- `IDE or Development Framework`_. This assists you in developing, debugging, and deploying Ethereum applications. 
+* `Web3 JavaScript API <https://github.com/ethereum/wiki/wiki/JavaScript-API>`__ - This is the main
+  JavaScript SDK to use when you want to interact with an Ethereum node.
+* `JSON RPC API <https://github.com/ethereum/wiki/wiki/JSON-RPC>`__ - This is
+  the low level JSON RPC 2.0 interface to interface with a node. This API is
+  used by the `Web3 JavaScript API <https://github.com/ethereum/wiki/wiki/JavaScript-API>`__.
+* `Solidity Documentation <https://solidity.readthedocs.org/en/latest/>`__ -
+  Solidity is the Ethereum developed Smart Contract language, which compiles to
+  EVM (Ethereum Virtual Machine) opcodes.
+* :ref:`test-networks` - Test networks help developers develop and test
+  Ethereum code and network interactions without spending their own Ether on
+  the main network. Test network options are listed below.
+* :ref:`IDE-or-development-framework`. This assists you in developing,
+  debugging, and deploying Ethereum applications. 
 
 
 .. _ethereum-high-level-languages:
@@ -60,6 +68,8 @@ Mutan (Deprecated)
 `Mutan <https://github.com/obscuren/mutan>`_ is a statically typed, C-like language designed and developed by Jeffrey Wilcke. It is no longer maintained.
 
 
+.. _IDE-or-development-framework:
+
 IDEs/Frameworks
 ================================================================================
 
@@ -75,6 +85,7 @@ TODO
 * `Embark <https://iurimatias.github.io/embark-framework/>`__ - Embark is a Ðapp development framework written in JavaScript.
 * `EtherScripter \(obsolete, discontinued\) <http://etherscripter.com/0-5-1/>`_
 * `Resilience Raw Transaction Broadcaster <https://github.com/resilience-me/broadcaster/>`_
+
 
 Base Layer Services
 =================================================
@@ -107,8 +118,10 @@ having to actually pay the high gas costs of executing them on-chain.
 .. _computation_market_main_website: http://www.ethereum-computation-market.com/
 .. _computation_market_documentation: http://docs.ethereum-computation-market.com/
 
+
 The EVM
 ================================================================================
+
 The Ethereum Virtual Machine (EVM) is the runtime environment for smart contracts in Ethereum. It is not only sandboxed, but actually completely isolated, which means that code running inside the EVM has no access to network, filesystem, or other processes. Smart contracts even have limited access to other smart contracts.
 
 Contracts live on the blockchain in an Ethereum-specific binary format (EVM bytecode). However, contracts are typically written in an Ethereum high level language, compiled into byte code using an EVM compiler, and finally uploaded on the blockchain using an Ethereum client.


### PR DESCRIPTION
Cleaned up some broken links and formatting on the developer tools page.

![457d9b556f9acd9c1baf8e62b3ebebf5](https://cloud.githubusercontent.com/assets/824194/13531384/848fbb56-e1e3-11e5-91d4-22c3d7a8b973.jpg)
