### PR TITLE
Switched all build.ethdev.com references to build.ethereum.org

### DIFF
--- a/old-docs-for-reference/go-ethereum-wiki.rst/Building-Ethereum.rst
+++ b/old-docs-for-reference/go-ethereum-wiki.rst/Building-Ethereum.rst
@@ -32,4 +32,4 @@ subsections.
 
 Further links \* `Compiled binaries on launchpad.net buildbot
 listings <https://launchpad.net/~ethereum>`__ \* `Ethereum
-buildbot <https://build.ethdev.com/>`__
+buildbot <https://build.ethereum.org/>`__

--- a/old-docs-for-reference/go-ethereum-wiki.rst/Installation-Instructions-for-ARM.rst
+++ b/old-docs-for-reference/go-ethereum-wiki.rst/Installation-Instructions-for-ARM.rst
@@ -9,7 +9,7 @@ RasPi 2
 -------
 
 1. Download the `precompiled binary from master
-   branch <https://build.ethdev.com/builds/ARM%20Go%20master%20branch/geth-ARM-latest.tar.bz2>`__
+   branch <https://build.ethereum.org/builds/ARM%20Go%20master%20branch/geth-ARM-latest.tar.bz2>`__
 2. Copy it to a location in $PATH (i.e. /usr/bin/local)
 3. Run ``geth``
 

--- a/old-docs-for-reference/go-ethereum-wiki.rst/Installation-instructions-for-Windows.rst
+++ b/old-docs-for-reference/go-ethereum-wiki.rst/Installation-instructions-for-Windows.rst
@@ -5,9 +5,9 @@ Download stable binaries
 ------------------------
 
 All versions of Geth are built and available for download at
-https://build.ethdev.com/builds/Windows%20Go%20master%20branch/. The
+https://build.ethereum.org/builds/Windows%20Go%20master%20branch/. The
 latest version is always available as
-`Geth-Win64-latest.zip <https://build.ethdev.com/builds/Windows%20Go%20master%20branch/Geth-Win64-latest.zip>`__
+`Geth-Win64-latest.zip <https://build.ethereum.org/builds/Windows%20Go%20master%20branch/Geth-Win64-latest.zip>`__
 
 1. Download zip file
 2. Extract geth.exe from zip

--- a/old-docs-for-reference/main-wiki.rst/FAQ.rst
+++ b/old-docs-for-reference/main-wiki.rst/FAQ.rst
@@ -154,7 +154,7 @@ How to install development builds?
 -  `Building on
    Ubuntu <https://github.com/ethereum/cpp-ethereum/wiki/Building-on-Ubuntu#user-content-trusty-1404>`__
 -  Builds
--  `Ethdev Buildbot <http://build.ethdev.com/waterfall>`__
+-  `Ethdev Buildbot <http://build.ethereum.org/waterfall>`__
 
 How to install the clients from source?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/old-docs-for-reference/main-wiki.rst/Home.rst
+++ b/old-docs-for-reference/main-wiki.rst/Home.rst
@@ -62,5 +62,5 @@ https://github.com/ethereum/webthree-umbrella (C++) -
 https://github.com/ethereum/pyethapp (Python)
 
 To see the state of the latest Ethereum builds, see the `Buildbot
-instance <http://build.ethdev.com/console>`__ for Go and Python and the
+instance <http://build.ethereum.org/console>`__ for Go and Python and the
 `Jenkins instance <http://52.28.164.97/>`__ for C++.

--- a/old-docs-for-reference/main-wiki.rst/Raspberry-Pi-instructions.rst
+++ b/old-docs-for-reference/main-wiki.rst/Raspberry-Pi-instructions.rst
@@ -100,7 +100,7 @@ Just get the binaries
 
 Alternativly, you can use the linux system of your choice and and get
 the arm binaries here: \*
-https://build.ethdev.com/builds/ARM%20Go%20develop%20branch/geth-ARM-latest.tar.bz2
+https://build.ethereum.org/builds/ARM%20Go%20develop%20branch/geth-ARM-latest.tar.bz2
 (go) \*
 https://github.com/doublethinkco/webthree-umbrella-cross/releases/tag/crosseth-armhf-apt-2015-12-31
 (cpp-ethereum)

--- a/source/ethereum-clients/cpp-ethereum/installing-binaries/osx-dmg.rst
+++ b/source/ethereum-clients/cpp-ethereum/installing-binaries/osx-dmg.rst
@@ -17,4 +17,4 @@ are out of luck.  Sorry!
 
 Here is the
 `cpp-ethereum v1.2.2 OS X DMG
-<https://build.ethdev.com/cpp-binaries-data/release-1.2.2/Ethereum.dmg>`_ for Homestead.
+<https://build.ethereum.org/cpp-binaries-data/release-1.2.2/Ethereum.dmg>`_ for Homestead.

--- a/source/ethereum-clients/cpp-ethereum/installing-binaries/windows-installer.rst
+++ b/source/ethereum-clients/cpp-ethereum/installing-binaries/windows-installer.rst
@@ -19,4 +19,4 @@ The vast majority of individuals using Windows have 64-bit hardware now.
 
 Here is the
 `cpp-ethereum v1.2.2 Windows installer
-<https://build.ethdev.com/cpp-binaries-data/release-1.2.2/Ethereum.exe>`_ for Homestead.
+<https://build.ethereum.org/cpp-binaries-data/release-1.2.2/Ethereum.exe>`_ for Homestead.

--- a/source/mining.rst
+++ b/source/mining.rst
@@ -353,7 +353,7 @@ Use ethminer ``--list-devices`` to list possible numbers to substitute for the X
 
 
 
-To start mining on Windows, first `download the geth windows binary <https://build.ethdev.com/builds/Windows%20Go%20master%20branch/>`_.
+To start mining on Windows, first `download the geth windows binary <https://build.ethereum.org/builds/Windows%20Go%20master%20branch/>`_.
 
 * Unzip Geth (right-click and select unpack) and launch Command Prompt. Use `cd` to navigate to the location of the Geth data folder. (e.g. ``cd /`` to go to the ``C:`` drive)
 * Start geth by typing ``geth --rpc``.


### PR DESCRIPTION
The ETHDEV brand is being actively deprecated, and these aliases point to the same machines.
Partial work towards fixing https://github.com/ethereum/webthree-umbrella/issues/365