### PR TITLE
Added notes at the top of the Windows, Linux and OS X specific buildi…

### DIFF
--- a/source/ethereum-clients/cpp-ethereum/building-from-source/linux.rst
+++ b/source/ethereum-clients/cpp-ethereum/building-from-source/linux.rst
@@ -3,6 +3,9 @@
 Building for Linux
 ################################################################################
 
+(Start at :ref:`Building from source`. These are the Linux specific steps.
+That is the starting point)
+
 NOTE - It may be possible to get the client working for Linux 32-bit, by
 disabling EVMJIT and maybe other features too.  We might accept
 pull-requests to add such support, but we will not put any of our

--- a/source/ethereum-clients/cpp-ethereum/building-from-source/osx.rst
+++ b/source/ethereum-clients/cpp-ethereum/building-from-source/osx.rst
@@ -2,6 +2,9 @@
 Building for OS X
 ================================================================================
 
+(Start at :ref:`Building from source`. These are the OS X specific steps.
+That is the starting point)
+
 It is impossible for us to avoid OS X build breaks because `Homebrew is a "rolling
 release" package manager
 <https://github.com/ethereum/webthree-umbrella/issues/118>`_

--- a/source/ethereum-clients/cpp-ethereum/building-from-source/windows.rst
+++ b/source/ethereum-clients/cpp-ethereum/building-from-source/windows.rst
@@ -2,6 +2,9 @@
 Building for Windows
 ================================================================================
 
+(Start at :ref:`Building from source`. These are the Windows specific steps.
+That is the starting point)
+
 We support **only 64-bit** builds and only for the following versions of Windows:
 
 - `Windows 7 <https://en.wikipedia.org/wiki/Windows_7>`_


### PR DESCRIPTION
…ng from source steps for cpp-ethereum, noting that these "nodes" are not the starting point for the instructions.