### PR TITLE
Renamed all the Ethereum client RST files as index.rst, so they have …

### DIFF
--- a/source/ethereum-clients/ethereumh/index.rst
+++ b/source/ethereum-clients/ethereumh/index.rst
@@ -7,7 +7,7 @@ ethereumH
 This package provides a tool written in Haskell to allow you to connect to
 the Ethereum blockchain
 
-Links
---------------------------------------------------------------------------------
+Links:
+
 * Github: https://github.com/jamshidh/ethereum-client-haskell
 * BlockApps: http://www.blockapps.net/

--- a/source/ethereum-clients/ethereumj/index.rst
+++ b/source/ethereum-clients/ethereumj/index.rst
@@ -15,8 +15,8 @@ Ethereum(J) supports CPU mining.  It is currently implemented in pure Java
 and can be used in private and test networks. You may even mine on the
 live Ethereum network, even though it is not economically feasible.
 
-Links
---------------------------------------------------------------------------------
+Links:
+
 * Blog: http://ethereumj.io/
 * Github: https://github.com/ethereum/ethereumj
 * Gitter chat: https://gitter.im/ethereum/ethereumj

--- a/source/ethereum-clients/ethereumjs-lib/index.rst
+++ b/source/ethereum-clients/ethereumjs-lib/index.rst
@@ -18,8 +18,8 @@ ethereumjs-lib
 * `devp2p <https://github.com/ethereumjs/node-devp2p>`_ - The networking protocol
 * `devp2p-dpt <https://github.com/ethereumjs/node-devp2p-dpt>`_ - The disputed peer table
 
-Links
---------------------------------------------------------------------------------
+Links:
+
 * Github: https://github.com/ethereumjs/ethereumjs-lib
 * Join the Gitter chat: https://gitter.im/ethereum/ethereumjs-lib
 

--- a/source/ethereum-clients/go-ethereum/index.rst
+++ b/source/ethereum-clients/go-ethereum/index.rst
@@ -12,8 +12,7 @@ The go-ethereum client is commonly referred to as **geth**, which is the the com
 * explore block history
 * and much much more
 
-Links
---------------------------------------------------------------------------------
+Links:
 
 * Website: http://ethereum.github.io/go-ethereum/
 * Github: https://github.com/ethereum/go-ethereum

--- a/source/ethereum-clients/index.rst
+++ b/source/ethereum-clients/index.rst
@@ -9,10 +9,10 @@ Ethereum Clients
 
    choosing-a-client.rst
    cpp-ethereum/index.rst
-   go-ethereum/go-ethereum.rst
-   pyethapp/pyethapp.rst
-   ethereumjs-lib/ethereumjs-lib.rst
-   ethereumj/ethereumj.rst
-   ethereumh/ethereumh.rst
-   parity/parity.rst
-   ruby-ethereum/ruby-ethereum.rst
+   go-ethereum/index.rst
+   pyethapp/index.rst
+   ethereumjs-lib/index.rst
+   ethereumj/index.rst
+   ethereumh/index.rst
+   parity/index.rst
+   ruby-ethereum/index.rst

--- a/source/ethereum-clients/parity/index.rst
+++ b/source/ethereum-clients/parity/index.rst
@@ -6,9 +6,13 @@ Parity
 
 **Parity** claims to be the world's fastest and lightest Ethereum client. It is written in the Rust language, which offers improved reliability, performance, and code clarity. Parity is being developed by `Ethcore <https://ethcore.io>`_, which was founded by several members of the Ethereum Foundation.
 
-
-Links
---------------------------------------------------------------------------------
 * Website: https://ethcore.io/parity.html
 * Github: https://github.com/ethcore/parity
 * Gitter chat: https://gitter.im/ethcore/parity
+
+Arch Linux packages are community maintained by `Afri Schoedon <https://github.com/5chdn>`_ and quininer.
+
+* https://aur.archlinux.org/packages/parity/ (stable, latest release)
+* https://aur.archlinux.org/packages/parity-git/ (unstable, latest develop)
+
+Some people have reported success with Parity on Raspberry Pi 2.

--- a/source/ethereum-clients/pyethapp/index.rst
+++ b/source/ethereum-clients/pyethapp/index.rst
@@ -11,8 +11,7 @@ pyethapp leverages two ethereum core components to implement the client:
 * `pyethereum <https://github.com/ethereum/pyethereum>`_ - the core library, featuring the blockchain, the ethereum virtual machine, mining
 * `pydevp2p <https://github.com/ethereum/pydevp2p>`_ - the p2p networking library, featuring node discovery for and transport of multiple services over multiplexed and encrypted connections
 
-Links
---------------------------------------------------------------------------------
+Links:
 
 * Github: https://github.com/ethereum/pyethapp
 * Wiki: https://github.com/ethereum/pyethapp/wiki/Getting-Started

--- a/source/ethereum-clients/ruby-ethereum/index.rst
+++ b/source/ethereum-clients/ruby-ethereum/index.rst
@@ -7,15 +7,14 @@ ruby-ethereum
 **ruby-ethereum** is an implementation of the :ref:`Ethereum Virtual Machine <the-EVM>` written in Ruby.
 
 
-Links
---------------------------------------------------------------------------------
+Links:
 
 * Github: https://github.com/janx/ruby-ethereum
 * Gem: https://rubygems.org/gems/ruby-ethereum
 
 
-Related
---------------------------------------------------------------------------------
+Related:
+
 * `ruby-serpent <https://github.com/janx/ruby-serpent>`_:  Ruby binding to the `Ethereum Serpent <https://github.com/ethereum/wiki/wiki/Serpent>`_ compiler. 
 * `ethereum-ruby <https://github.com/DigixGlobal/ethereum-ruby>`_: a pure-Ruby JSON-RPC wrapper for communicating with an Ethereum node. To use this library you will need to have a running Ethereum node with IPC support enabled (default). Currently, the :ref:`go-ethereum` client is supported.
 


### PR DESCRIPTION
…nice, default URLs.

Removed the heavy headings which introduced unnecessary Links pages for each.
Added details on the new Parity ArchLinux packages, and about the success somebody had running Parity on Rpi2.