### PR TITLE
Cleanup up the C++ building from source instructions.

### DIFF
--- a/source/ethereum-clients/cpp-ethereum/building-from-source/index.rst
+++ b/source/ethereum-clients/cpp-ethereum/building-from-source/index.rst
@@ -3,34 +3,23 @@
 Building from source
 ================================================================================
 
-The **cpp-ethereum** codebase is spread over several Git repositories which
-are all grouped as sub-modules under the 
+The **cpp-ethereum** codebase is spread over several
+Git repositories which are all grouped as sub-modules under the 
 `webthree-umbrella <http://github.com/ethereum/webthree-umbrella>`_ repo
-on Github.  We use `CMake <https://cmake.org/>`_ to generate build files on all platforms,
-meaning that the workflow is very similar whatever operating system you use: ::
+on Github.
 
-    git clone --recursive https://github.com/ethereum/webthree-umbrella.git
+We use a common `CMake <https://cmake.org/>`_ build system to generate
+platform-specific build files, meaning that the workflow is very similar
+whatever operating system you use:
 
-    git checkout release                                     Optionally, to switch to "release" branch
-    git submodule update                                     perform these two steps.
-
-    mkdir build                                              Make a directory for the build output
-    cd build                                                 Switch into that directory
-
-    cmake ..                                                 To generate a makefile.
-    make                                                     To build that makefile on the command-line
-    make -j <number>                                         Execute makefile with multiple cores in parallel
-
-    cmake -G "Visual Studio 12 2013 Win64" ..                To generate Visual Studio solution
-    msbuild cpp-ethereum.sln /p:Configuration=Release        To build that on the command-line
-
-    cmake -G Xcode ..                                        To generate xcode project
+* Install build tools and external packages (these are platform dependent)
+* Clone the source code from the **webthree-umbrella** git repository
+* Run CMake to generate a build file (makefile, Visual Studio solution, etc)
+* Build it
 
 
 Platform-specific instructions
 --------------------------------------------------------------------------------
-
-From there, follow the platform-specific instructions below.
 
 .. toctree::
    :maxdepth: 2

--- a/source/ethereum-clients/cpp-ethereum/building-from-source/linux.rst
+++ b/source/ethereum-clients/cpp-ethereum/building-from-source/linux.rst
@@ -4,9 +4,6 @@
 Building for Linux
 ################################################################################
 
-(Start at :ref:`Building from source`. These are the Linux specific steps.
-That is the starting point)
-
 NOTE - It may be possible to get the client working for Linux 32-bit, by
 disabling EVMJIT and maybe other features too.  We might accept
 pull-requests to add such support, but we will not put any of our
@@ -18,6 +15,25 @@ the first thing which we need to do before we can start on
 steps.   If you are using as different distro and hit issues, please
 `let us know <https://gitter.im/ethereum/cpp-ethereum>`_.
 
+
+Clone the repository
+--------------------------------------------------------------------------------
+
+To clone the source code, execute the following command: ::
+
+    git clone --recursive https://github.com/ethereum/webthree-umbrella.git
+
+Build on the command-line
+--------------------------------------------------------------------------------
+
+**ONLY** after you have installed your dependencies (the rest of this doc!): ::
+
+    mkdir build                                              Make a directory for the build output
+    cd build                                                 Switch into that directory
+
+    cmake ..                                                 To generate a makefile.
+    make                                                     To build that makefile on the command-line
+    make -j <number>                                         (or) Execute makefile with multiple cores in parallel
 
 
 Installing dependencies for Ubuntu

--- a/source/ethereum-clients/cpp-ethereum/building-from-source/osx.rst
+++ b/source/ethereum-clients/cpp-ethereum/building-from-source/osx.rst
@@ -2,8 +2,7 @@
 Building for OS X
 ================================================================================
 
-(Start at :ref:`Building from source`. These are the OS X specific steps.
-That is the starting point)
+**BEWARE!  Here be dragons!**
 
 It is impossible for us to avoid OS X build breaks because `Homebrew is a "rolling
 release" package manager
@@ -23,11 +22,13 @@ on that existing issue.  If you don't see anything which looks similar,
 please create a new issue, detailing your OS X version, cpp-ethereum version,
 hardware and any other details you think might be relevant.   Please add
 verbose log files via `gist.github.com <http://gist.github.com>`_ or a
-similar service.   The `cpp-ethereum gitter channel
-<https://gitter.im/ethereum/cpp-ethereum>`_ is where we hang out, and try
+similar service.
+
+The `cpp-ethereum-development 
+<https://gitter.im/ethereum/cpp-ethereum-development>`_ gitter channel is where we hang out, and try
 to work together to get known issues resolved.
 
-We **only** support the two most recent OS X versions:
+We only support the two most recent OS X versions:
 
 - `OS X Yosemite (10.10) <https://en.wikipedia.org/wiki/OS_X_Yosemite>`_
 - `OS X El Capitan (10.11) <https://en.wikipedia.org/wiki/OS_X_El_Capitan>`_
@@ -61,16 +62,25 @@ Install all required external dependencies ::
     brew update
     brew upgrade
     brew install boost --c++11
-    brew install cmake cryptopp miniupnpc leveldb gmp jsoncpp libmicrohttpd libjson-rpc-cpp llvm37
-    brew install homebrew/versions/v8-315
+    brew install cmake cryptopp miniupnpc leveldb gmp jsoncpp libmicrohttpd libjson-rpc-cpp
+    brew install homebrew/versions/llvm38
     brew install qt5 --with-d-bus
 
 **NB:  The Qt5 step takes many hours on most people's machines.**  This is because it is
 using non-default build settings which result in build-from-source.  It also appears
 to use around 20Gb of temporary disk space.   Beware!
 
+
+Clone the repository
+--------------------------------------------------------------------------------
+
+To clone the source code, execute the following command: ::
+
+    git clone --recursive https://github.com/ethereum/webthree-umbrella.git
+
 You can either generate a makefile and build on command-line or generate an
 Xcode project and build Ethereum in the IDE.
+
 
 Generate a makefile
 --------------------------------------------------------------------------------
@@ -80,10 +90,10 @@ From the project root: ::
     mkdir build
     cd build
     cmake ..
-    make -j4             (or different value, depending on your number of cores)
+    make -j4             (or different value, depending on your number of CPU cores)
     make install
 
-This will also install the cli tool and libs into /usr/local.
+This will also install the cli tool and libs into **/usr/local** and **/usr/bin**.
 
 Xcode
 --------------------------------------------------------------------------------
@@ -95,12 +105,3 @@ From the project root: ::
     cmake -G Xcode ..
 
 This will generate an Xcode project file along with some configs for you: **cpp-ethereum.xcodeproj**. Open this file in XCode and you should be able to build the project
-
-
-Troubleshooting
---------------------------------------------------------------------------------
-
-* error: verify_app failed - you will need to use the `QTBUG-50155-workaround <https://github.com/ethereum/webthree-umbrella/wiki/QTBUG-50155-workaround>`_
-* Build error "non-virtual thunk to CryptoPP::Rijndael::Dec::AdvancedProcessBlocks" - this is due to a `bad bottle for CryptoPP 5.6.3 <https://github.com/ethereum/webthree-umbrella/wiki/CryptoPP-5.6.3-workaround>`_
-* Unexpected "No such file or directory (or similar)" error e.g. `Sentinel.h.tmp`, `AdminUtilsFace.h.tmp`. Read the `libjson-rpc-cpp workaround <https://github.com/ethereum/webthree-umbrella/wiki/libjson-rpc-cpp-OS-X-workaround>`_
-* Build or runtime errors, complaining about missing `libmicrohttpd.10.dylib <https://github.com/ethereum/webthree-umbrella/wiki/homebrew-47806-workaround>`_

--- a/source/ethereum-clients/cpp-ethereum/building-from-source/windows.rst
+++ b/source/ethereum-clients/cpp-ethereum/building-from-source/windows.rst
@@ -2,9 +2,6 @@
 Building for Windows
 ================================================================================
 
-(Start at :ref:`Building from source`. These are the Windows specific steps.
-That is the starting point)
-
 We support **only 64-bit** builds and only for the following versions of Windows:
 
 - `Windows 7 <https://en.wikipedia.org/wiki/Windows_7>`_
@@ -60,6 +57,14 @@ which we depend on: ::
     cd webthree-helpers\extdep
     getstuff.bat
     cd ..\..
+
+
+Clone the repository
+--------------------------------------------------------------------------------
+
+To clone the source code, execute the following command: ::
+
+    git clone --recursive https://github.com/ethereum/webthree-umbrella.git
 
 
 Build from within Visual Studio


### PR DESCRIPTION
Removed references to switching to the release branch.
We don't really want people doing that anyway (besides the fact that right now the sub-modules are different between develop and release).