### PR TITLE
Remove section about incremental build on Windows

### DIFF
--- a/source/ethereum-clients/cpp-ethereum/building-from-source/windows.rst
+++ b/source/ethereum-clients/cpp-ethereum/building-from-source/windows.rst
@@ -72,17 +72,3 @@ Build on the command-line
 Alternatively, you can build the project on the command-line, like so: ::
 
     cmake --build . --config RelWithDebInfo
-
-
-Incremental builds
---------------------------------------------------------------------------------
-
-After your first successful build, it should generally be possible to do an
-incremental build like so, from the root of the project: ::
-
-    git pull
-    del build\CMakeCache.txt
-    cd build
-    cmake -G "Visual Studio 14 2015 Win64" ..
-
-And then build on command-line or in Visual Studio as before.


### PR DESCRIPTION
Remove the section about incremental building of cpp-ethereum with Visual Studio. It is simply not needed. With Visual Studio projects generated with cmake it is enough to update the source and build. In case of cmake files modification the whole VS solution will be re-generated.