### PR TITLE
Fix JavaScript example for manual contract creation

### DIFF
--- a/source/contracts-and-transactions/contracts.rst
+++ b/source/contracts-and-transactions/contracts.rst
@@ -275,10 +275,10 @@ You will now create a contract on the blockchain by `sending a transaction <http
 
 .. code:: js
 
-    primaryAddress = eth.accounts[0]
-    abi  = [{ constant: false, inputs: [{ name: 'a', type: 'uint256' } ]
-    MyContract = eth.contract.abi;
-    contract = MyContract.new(arg1, arg2, ...,{from: primaryAddress, data: evmByteCodeFromPreviousSection})
+    var primaryAddress = eth.accounts[0]
+    var abi = [{ constant: false, inputs: [{ name: 'a', type: 'uint256' } ]
+    var MyContract = eth.contract(abi)
+    var contract = MyContract.new(arg1, arg2, ..., {from: primaryAddress, data: evmByteCodeFromPreviousSection})
 
 All binary data is serialised in hexadecimal form. Hex strings always have a
 hex prefix ``0x``.


### PR DESCRIPTION
This fixes some "bad language" in the JavaScript examples for creating a contract manually from an ABI object, specifically:

1. It uses the `var` keyword for creating object references as is customary in JS
1. It fixes a syntax error related to the `contract` function invocation
1. Remove the redundant semicolon