### PR TITLE
Fix client release links

### DIFF
--- a/source/ethereum-clients/choosing-a-client.rst
+++ b/source/ethereum-clients/choosing-a-client.rst
@@ -15,14 +15,14 @@ is unambiguous.  It keeps the door open for new innovation.  It keeps us
 all honest.  However, it can be very confusing for end-users, because there
 is no universal "Ethereum Installer" for them to use.
 
-As of September 2016, the leading implementations are :ref:`go-ethereum` and :ref:`Parity`.
+As of October 2016, the leading implementations are :ref:`go-ethereum` and :ref:`Parity`.
 
 +------------------------+------------+------------------------+-------------------------------------+
 | Client                 | Language   | Developers             | Latest release                      |
 +========================+============+========================+=====================================+
-| :ref:`go-ethereum`     | Go         | `Ethereum Foundation`_ | `go-ethereum-v1.4.14`_              |
+| :ref:`go-ethereum`     | Go         | `Ethereum Foundation`_ | `go-ethereum-v1.4.18`_              |
 +------------------------+------------+------------------------+-------------------------------------+
-| :ref:`Parity`          | Rust       | `Ethcore`_             | `Parity-v1.3.2`_                    |
+| :ref:`Parity`          | Rust       | `Ethcore`_             | `Parity-v1.3.9`_                    |
 +------------------------+------------+------------------------+-------------------------------------+
 | :ref:`cpp-ethereum`    | C++        | `Ethereum Foundation`_ | `cpp-ethereum-v1.3.0`_              |
 +------------------------+------------+------------------------+-------------------------------------+
@@ -43,11 +43,11 @@ As of September 2016, the leading implementations are :ref:`go-ethereum` and :re
 .. _Ethcore: https://ethcore.io/
 .. _Jan Xie: https://github.com/janx/
 
-.. _go-ethereum-v1.4.14: https://github.com/ethereum/go-ethereum/releases/tag/v1.4.14
+.. _go-ethereum-v1.4.18: https://github.com/ethereum/go-ethereum/releases/tag/v1.4.18
 .. _cpp-ethereum-v1.3.0: https://github.com/bobsummerwill/cpp-ethereum/releases/tag/v1.3.0
 .. _ethereumjs-lib-v3.0.0: https://github.com/ethereumjs/ethereumjs-lib/releases/tag/v3.0.0
 .. _ethereumJ-v1.3.1: https://github.com/ethereum/ethereumj/releases/tag/1.3.1
-.. _Parity-v1.3.2: https://github.com/ethcore/parity/releases/tag/v1.3.2
+.. _Parity-v1.3.9: https://github.com/ethcore/parity/releases/tag/v1.3.9
 .. _pyethapp-v1.5.0: https://github.com/ethereum/pyethapp/releases/tag/v1.5.0
 .. _ruby-ethereum-v0.9.6: https://rubygems.org/gems/ruby-ethereum/versions/0.9.6
 


### PR DESCRIPTION
Updated client release links to latest versions (geth 1.4.18 and Parity 1.3.9).
