### PR TITLE
OpenCL-headers comments and typo corrections

### DIFF
--- a/source/ethereum-clients/cpp-ethereum/building-from-source/linux-opensuse.rst
+++ b/source/ethereum-clients/cpp-ethereum/building-from-source/linux-opensuse.rst
@@ -4,17 +4,23 @@ Installing dependencies for openSUSE
 ################################################################################
 
 Here is how to get the dependencies needed to build the latest
-webthree-umbrella on OpenSUSE. This was done on Leap 42.1, but there should be equivalent packages available for Tumbleweed and 13.x.
+webthree-umbrella on OpenSUSE. This was done on Leap 42.1 and 42.2, but there should be equivalent packages available for Tumbleweed and 13.x.
 
 First install dependencies provided by the main repos: ::
 
     zypper in git automake autoconf libtool cmake gcc gcc-c++ \
         xkeyboard-config leveldb-devel boost-devel gmp-devel \
-        cryptopp-devel libminiupnpc-devel libqt5-qtbase-common-devel \
-        libqt5-qtdeclarative-devel libQTWebKit-devel libqt5-qtwebengine-devel \
+        libcryptopp-devel libminiupnpc-devel libqt5-qtbase-common-devel \
+        libqt5-qtdeclarative-devel libQtWebKit-devel libqt5-qtwebengine-devel \
         libQt5Concurrent-devel Mesa ncurses-devel readline-devel libcurl-devel \
         llvm llvm-clang llvm-clang-devel llvm-devel libLLVM binutils \
-        libmicrohttp-devel jsoncpp-devel opencl-headers-1.2 zlib-devel 
+        libmicrohttpd-devel jsoncpp-devel opencl-headers-1.2 zlib-devel 
+
+If Opencl-headers-1.2 is not found, you can install it manually from the CLI:
+    zypper addrepo http://download.opensuse.org/repositories/home:valmar73:crystfel-releases/openSUSE_13.1/home:valmar73:crystfel-releases.repo
+    zypper refresh
+    zypper install opencl-headers-1.2
+
 
 It may be possible to use the generic `libOpenCL1`, but I have only tested with the
 AMD proprietary package from the AMD drivers repo `fglrx64_opencl_SUSE421`
@@ -29,3 +35,5 @@ build service package search and YaST 1-Click Install:
 If you also have v8 from the chromium repo installed the devel package will
 default to the 4.x branch which will not work. Use YaST or zypper to downgrade
 this package to 3.x
+
+Note that Opencl-headers is used to mine the chain with GPU. If this is not a requirement, you can bypass it when creating the makefile (cmake -DETHASHCL=0 .. ) instead of (cmake ..)


### PR DESCRIPTION
Some typos (?) in the dependencies - namely libcryptopp-devel and libQtWebKit-devel.
Opencl-headers seems to be a major issue.

Even when the lib is manually installed (zypper addrepo http://download.opensuse.org/repositories/home:valmar73:crystfel-releases/openSUSE_13.1/home:valmar73:crystfel-releases.repo
zypper refresh
zypper install opencl-headers-1.2) it is not recognized when cmake .. is called;