### PR TITLE
update the docs to reflect the need to git submodule init

### DIFF
--- a/source/ethereum-clients/cpp-ethereum/building-from-source/linux.rst
+++ b/source/ethereum-clients/cpp-ethereum/building-from-source/linux.rst
@@ -14,6 +14,7 @@ To clone the source code, execute the following commands:
 
     git clone --recursive https://github.com/ethereum/cpp-ethereum.git
     cd cpp-ethereum
+    git submodule update --init
 
 
 Installing dependencies


### PR DESCRIPTION
In attempting to build the project it was discovered that the git submodule init step is not listed in the docs.