### PR TITLE
update ethcore.io redirect

### DIFF
--- a/source/ethereum-clients/parity/index.rst
+++ b/source/ethereum-clients/parity/index.rst
@@ -4,11 +4,11 @@
 Parity
 ################################################################################
 
-**Parity** claims to be the world's fastest and lightest Ethereum client. It is written in the Rust language, which offers improved reliability, performance, and code clarity. Parity is being developed by `Ethcore <https://ethcore.io>`_, which was founded by several members of the Ethereum Foundation.
+**Parity** claims to be the world's fastest and lightest Ethereum client. It is written in the Rust language, which offers improved reliability, performance, and code clarity. Parity is being developed by `Parity Technologies (Ethcore) <https://parity.io>`_, which was founded by several members of the Ethereum Foundation.
 
-* Website: https://ethcore.io/parity.html
-* GitHub: https://github.com/ethcore/parity
-* Gitter chat: https://gitter.im/ethcore/parity
+* Website: https://parity.io/
+* GitHub: https://github.com/paritytech/parity
+* Gitter chat: https://gitter.im/paritytech/parity
 
 Arch Linux packages are community maintained by `Afri Schoedon <https://github.com/5chdn>`_ and quininer.
 


### PR DESCRIPTION
ethcore.io now redirects to parity.io (paritytech)