### PR TITLE
Missing parameter in call to eth_getBalance

### DIFF
--- a/source/contracts-and-transactions/accessing-contracts-and-transactions.rst
+++ b/source/contracts-and-transactions/accessing-contracts-and-transactions.rst
@@ -62,7 +62,7 @@ note that data in these examples will differ on your local node. If you want to 
     > curl --data '{"jsonrpc":"2.0","method":"eth_coinbase", "id":1}' localhost:8545
     {"id":1,"jsonrpc":"2.0","result":["0xeb85a5557e5bdc18ee1934a89d8bb402398ee26a"]}
 
-    > curl --data '{"jsonrpc":"2.0","method":"eth_getBalance", "params": ["0xeb85a5557e5bdc18ee1934a89d8bb402398ee26a"], "id":2}' localhost:8545
+    > curl --data '{"jsonrpc":"2.0","method":"eth_getBalance", "params": ["0xeb85a5557e5bdc18ee1934a89d8bb402398ee26a", "latest"], "id":2}' localhost:8545
     {"id":2,"jsonrpc":"2.0","result":"0x1639e49bba16280000"}
 
 Remember when we said that numbers are hex encoded? In this case the balance is returned in wei as a hex string. If we want to have the balance in


### PR DESCRIPTION
Added second parameter to "eth_getBalance" example call, as per https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getbalance.

Without this parameter, the RPC interface throws an error:

{"jsonrpc":"2.0","id":2,"error":{"code":-32602,"message":"missing value for required argument 1"}}
