### PR TITLE
Feature/customgenesis example fixes

### DIFF
--- a/source/network/test-networks.rst
+++ b/source/network/test-networks.rst
@@ -230,7 +230,7 @@ blockchain unless they have the same genesis block, so you can make as many priv
   {
       "nonce": "0x0000000000000042",     "timestamp": "0x0",
       "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "extraData": "0x0",     "gasLimit": "0x8000000",     "difficulty": "0x400",
+      "extraData": "0x00",     "gasLimit": "0x8000000",     "difficulty": "0x400",
       "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",
       "coinbase": "0x3333333333333333333333333333333333333333",     "alloc": {     }
   }

--- a/source/network/test-networks.rst
+++ b/source/network/test-networks.rst
@@ -228,7 +228,7 @@ blockchain unless they have the same genesis block, so you can make as many priv
 .. code-block:: JSON
 
   {
-      "nonce": "0x0000000000000042",     "timestamp": "0x0",
+      "config": { }, "nonce": "0x0000000000000042",     "timestamp": "0x0",
       "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
       "extraData": "0x00",     "gasLimit": "0x8000000",     "difficulty": "0x400",
       "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
I found two issues with the CustomGenesis.json example while trying to build a private network.

- There was an error with the extraData being 0x0. The fix was to use 0x00
- There looks to be a change in the required fields. The error was a missing config section. Adding one removed that error.

I'm using geth version 1.6.7-stable