### PR TITLE
Fix broken inline link to Backup & Restore on Account Management page

### DIFF
--- a/source/account-management.rst
+++ b/source/account-management.rst
@@ -37,7 +37,7 @@ It is safe to transfer the entire directory or any individual keyfile between Et
 Creating an account
 ================================================================================
 
-.. Warning:: **Remember your passwords and :ref:`backup your keyfiles <backup-and-restore-accounts>`.** In order to send transactions from an account, including sending ether, you must have BOTH the keyfile and the password. Be absolutely sure to have a copy of your keyfile AND remember the password for that keyfile, and store them both as securely as possible. There are no escape routes here; lose the keyfile or forget your password and all your ether is gone. It is NOT possible to access your account without a password and there is no *forgot my password* option here. Do not forget it.
+.. Warning:: **Remember your passwords and** :ref:`backup your keyfiles <backup-and-restore-accounts>`. In order to send transactions from an account, including sending ether, you must have BOTH the keyfile and the password. Be absolutely sure to have a copy of your keyfile AND remember the password for that keyfile, and store them both as securely as possible. There are no escape routes here; lose the keyfile or forget your password and all your ether is gone. It is NOT possible to access your account without a password and there is no *forgot my password* option here. Do not forget it.
 
 Using ``geth account new``
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Nested inline markup is not supported in docutils, so link inside the bold was broken. I propose simple fix: move link out of bold area. [Here](https://i.imgur.com/ZrdhPOs.png) is the result of the fix applied.