### PR TITLE
Fix broken link to Shapeshift.io

### DIFF
--- a/source/ether.rst
+++ b/source/ether.rst
@@ -98,7 +98,7 @@ Exchange                   Currencies
 ========================== ============================
 
 .. _Bity: https://bity.com
-.. _Shapeshift: shapeshift.io
+.. _Shapeshift: https://shapeshift.io
 
 
 Trading and price analytics


### PR DESCRIPTION
Compiled link to Shapeshift.io on the [Ether](http://www.ethdocs.org/en/latest/ether.html) page is currently [http://www.ethdocs.org/en/latest/shapeshift.io](http://www.ethdocs.org/en/latest/shapeshift.io), which gives 404. This PR fixes it.