### PR TITLE
web3py: update repository locations

### DIFF
--- a/source/connecting-to-clients/index.rst
+++ b/source/connecting-to-clients/index.rst
@@ -24,7 +24,7 @@ A number of libraries have been written to help address these issues, allowing a
 +----------------------+------------+-----------------------------------------------+
 | :ref:`ethereum-ruby` | Ruby       | https://github.com/DigixGlobal/ethereum-ruby  |
 +----------------------+------------+-----------------------------------------------+
-| :ref:`web3.py`       | Python     | https://github.com/pipermerriam/web3.py       |
+| :ref:`web3.py`       | Python     | https://github.com/ethereum/web3.py           |
 +----------------------+------------+-----------------------------------------------+
 
 Information on each library is provided in the following sections:

--- a/source/connecting-to-clients/web3.py/index.rst
+++ b/source/connecting-to-clients/web3.py/index.rst
@@ -6,11 +6,10 @@ web3.py
 
 **web3.py** is a pure-Python JSON-RPC wrapper for communicating with an
 Ethereum node. To use this library you will need to have a running Ethereum
-node with RPC or IPC enabled.
+node with HTTP or IPC enabled.
 
 
 Links:
 
-* Docs: http://web3py.readthedocs.io/en/latest/
-* GitHub: https://github.com/pipermerriam/web3.py
-* Optional utilities: https://github.com/carver/web3utils.py
+* Docs: http://web3py.readthedocs.io/en/stable/
+* GitHub: https://github.com/ethereum/web3.py


### PR DESCRIPTION
Updates python repository that moved to ethereum org.

Also:
- fix reference to json-rpc over HTTP
- web3utils is fully merged into web3.py now, link can be removed
- link to stable docs instead of beta docs