### PR TITLE
Add a link to download Visual C++ 2015 Build Tools

### DIFF
--- a/source/ethereum-clients/cpp-ethereum/building-from-source/windows.rst
+++ b/source/ethereum-clients/cpp-ethereum/building-from-source/windows.rst
@@ -64,7 +64,8 @@ solution file using CMake: ::
 
 Which should result in the creation of **cpp-ethereum.sln** in that build directory.
 
-**NOTE: We only support Visual Studio 2015 as of cpp-ethereum-v.1.3.0.**
+**NOTE: We only support Visual Studio 2015 as of cpp-ethereum-v.1.3.0. If you don't
+have it already, install the `Visual C++ 2015 Build Tools <http://landinghub.visualstudio.com/visual-cpp-build-tools>`_ **
 
 Double-clicking on that file should result in Visual Studio firing up. We suggest
 building **RelWithDebugInfo** configuration, but all others work.


### PR DESCRIPTION
Visual C++ 2015 Build Tools are pretty hard to find since Microsofts keeps pushing VS 2017. This is a link to the official Microsoft download page.