### PR TITLE
Update history-of-ethereum.rst. Remove dead link.

### DIFF
--- a/source/introduction/history-of-ethereum.rst
+++ b/source/introduction/history-of-ethereum.rst
@@ -92,7 +92,4 @@ The presence of large companies like UBS, IBM and Microsoft clearly indicated en
 * `DEVCON-1 talks Youtube playlist <https://www.youtube.com/playlist?list=PLJqWcTqh_zKHQUFX4IaVjWjfT2tbS4NVk>`_
 * `DEVCON-1 website <https://devcon.ethereum.org/>`_ full listing of presentations with links to the slides if available.
 
-History resources
-----------------------------------------
 
-* `a simple graphical timeline <http://ethereumtimeline.org/>`_


### PR DESCRIPTION
The only link under 'History Resources' is no longer valid. It just redirects to a godaddy domain page. Since it's the only link, I think it would make sense to remove the 'History Resources' section entirely.