### PR TITLE
Update testnet references from Morden to Ropsten

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -218,7 +218,10 @@ Glossary
       The Frontier pre-release, which launched on May 9th 2015. It was meant for developers to help test the limits of the Ethereum blockchain.
 
    morden
-      Morden is the first Ethereum alternative testnet. It is expected to continue throughout the Frontier and Homestead era.
+      Morden was the first Ethereum alternative testnet. 
+
+   ropsten
+      Ropsten is a testnet forked from Morden in November 2016 due to increasing mining difficulty, and a client consensus issue.
 
    testnet
       A mirror network of the production Ethereum network that is meant for testing. See Morden.

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -221,7 +221,7 @@ Glossary
       Morden was the first Ethereum alternative testnet. 
 
    ropsten
-      Ropsten is a testnet forked from Morden in November 2016 due to increasing mining difficulty, and a client consensus issue.
+      Ropsten is an active Ethereum testnet that replaced Morden in November 2016. It was started from a new genesis block due to a client consensus issue and increasing block times.
 
    testnet
       A mirror network of the production Ethereum network that is meant for testing. See Morden.

--- a/source/mining.rst
+++ b/source/mining.rst
@@ -84,7 +84,7 @@ In order to mine you need a fully synced Ethereum client that is enabled for min
 CPU mining
 ================================================================================
 
-You can use your computer's central processing unit (CPU) to mine ether. This is no longer profitable, since GPU miners are roughly two orders of magnitude more efficient. However, you can use CPU mining to mine on the Morden testnet or a private chain for the purposes of creating the ether you need to test contracts and transactions without spending your real ether on the live network.
+You can use your computer's central processing unit (CPU) to mine ether. This is no longer profitable, since GPU miners are roughly two orders of magnitude more efficient. However, you can use CPU mining to mine on the Ropsten testnet or a private chain for the purposes of creating the ether you need to test contracts and transactions without spending your real ether on the live network.
 
 .. note:: The testnet ether has no value other than using it for testing purposes (see :ref:`test-networks`).
 

--- a/source/network/connecting-to-the-network.rst
+++ b/source/network/connecting-to-the-network.rst
@@ -16,7 +16,7 @@ Ethereum network stats
 `EthStats\.net <https://ethstats.net/>`_ is a dashboard of live statistics of the Ethereum network. This dashboard displays important information such as the current block, hash difficulty, gas price, and gas spending. The nodes shown on the page are only a selection of actual nodes on the network.
 Anyone is allowed to add their node to the EthStats dashboard. The `Eth\-Netstats README on Github <https://github.com/cubedro/eth-netstats>`_ describes how to connect.
 
-`EtherNodes\.org <https://www.ethernodes.org/>`_ displays current and historical data on node count and other information on both the Ethereum mainnet and Morden testnet.
+`EtherNodes\.org <https://www.ethernodes.org/>`_ displays current and historical data on node count and other information on both the Ethereum mainnet and Ropsten testnet.
 
 `Distribution of client implementations on the current live network <https://etherchain.org/nodes>`_ - Realtime stats on EtherChain.
 

--- a/source/network/test-networks.rst
+++ b/source/network/test-networks.rst
@@ -4,10 +4,10 @@
 Test Networks
 ********************************************************************************
 
-Morden testnet
+Ropsten testnet
 ================================================================================
-Morden is a public Ethereum alternative testnet. It is expected to
-continue throughout the Frontier and Homestead milestones of the software.
+Ropsten is a public Ethereum alternative testnet. It is expected to
+continue through the Homestead release.
 
 Usage
 --------------------------------------------------------------------------------
@@ -15,16 +15,16 @@ Usage
 eth (C++ client)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This is supported natively on 0.9.93 and above. Pass the ``--morden`` argument in when starting any of the clients. e.g.:
+This is supported natively on 0.9.93 and above. Pass the ``--ropsten`` argument in when starting any of the clients. e.g.:
 
 .. code:: Console
 
-   > eth --morden
+   > eth --ropsten
 
 PyEthApp (Python client)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-PyEthApp supports the morden network from v1.0.5 onwards:
+PyEthApp currently only supports the old morden testnet. From v1.0.5 onwards:
 
 .. code:: Console
 
@@ -41,45 +41,21 @@ Details
 --------------------------------------------------------------------------------
 All parameters are the same as the main Ethereum network except:
 
--  Network Name: **Morden**
--  Network Identity: 2
--  genesis.json (given below);
--  Initial Account Nonce (``IAN``) is 2^20 (instead of 0 in all previous
-   networks).
+-  Network Name: **Ropsten**
+-  Network Identity: 3
+-  `genesis.json <https://github.com/paritytech/parity/blob/master/ethcore/res/ethereum/ropsten.json>`_
+-  Initial Account Nonce (``IAN``) is 0 (instead of 2^20 in the Morden testnet).
 
    -  All accounts in the state trie have nonce >= ``IAN``.
    -  Whenever an account is inserted into the state trie it is
       initialised with nonce = ``IAN``.
 
 -  Genesis generic block hash:
-   ``0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303``
+   ``41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d``
 -  Genesis generic state root:
-   ``f3f4696bbf3b3b07775128eb7a3763279a394e382130f27c21e70233e04946a9``
+   ``217b0bbcfb72e2d57e28f33cb361b9983513177755dc3f33ce3e7022ed62b77b``
 
-Morden's genesis.json
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code:: JSON
-
-	{
-			"nonce": "0x00006d6f7264656e",
-			"difficulty": "0x20000",
-			"mixhash": "0x00000000000000000000000000000000000000647572616c65787365646c6578",
-			"coinbase": "0x0000000000000000000000000000000000000000",
-			"timestamp": "0x00",
-			"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-			"extraData": "0x",
-			"gasLimit": "0x2FEFD8",
-			"alloc": {
-					"0000000000000000000000000000000000000001": { "balance": "1" },
-					"0000000000000000000000000000000000000002": { "balance": "1" },
-					"0000000000000000000000000000000000000003": { "balance": "1" },
-					"0000000000000000000000000000000000000004": { "balance": "1" },
-					"102e61f5d8f9bc71d0ad4a084df4e65e05ce0e1c": { "balance": "1606938044258990275541962092341162602522202993782792835301376" }
-			}
-	}
-
-Getting Morden testnet ether
+Getting Ropsten testnet ether
 --------------------------------------------------------------------------------
 
 Because of decreased mining difficulty on the testnet, ether can easily mined using your CPU/GPU (see :ref:`mining`).
@@ -203,7 +179,7 @@ geth (Go client)
 
 You either pre-generate or mine your own ether on a private
 testnet. It is a much more cost effective way of trying out
-Ethereum and you can avoid having to mine or find Morden test ether.
+Ethereum and you can avoid having to mine or find Ropsten test ether.
 
 The things that are required to specify in a private chain are:
  - Custom Genesis File


### PR DESCRIPTION
I did not include an inline genesis file for Ropsten as there was for Morden, since there are an inconvenient number of account allocations. I linked to the parity ropsten.json because it seems like the most reliable/long term source at the moment (I can't locate the "official" origin).