### PR TITLE
Cause tox test to fail on warning

### DIFF
--- a/rst_lint.py
+++ b/rst_lint.py
@@ -106,7 +106,7 @@ def lint(dir=SOURCE_DIR, log_level=WARNING):
                 sys.stdout.write(message)
             else:
                 sys.stderr.write(message)
-    if any(error.type == "ERROR" for error in errors):
+    if any((error.type == "ERROR" or error.type == "WARNING") for error in errors):
         sys.exit(1)
     else:
         sys.exit(0)

--- a/source/introduction/what-is-ethereum.rst
+++ b/source/introduction/what-is-ethereum.rst
@@ -62,7 +62,7 @@ Learn about Ethereum
 PR videos with some pathos:
 ---------------------------------
 
-* `Ethereum: the World Computer <https://www.youtube.com/watch?v=j23HnORQXvs>_
+* `Ethereum: the World Computer <https://www.youtube.com/watch?v=j23HnORQXvs>`_
 * `Ethereum -- your turn <https://vimeo.com/88959651>`_
 
 

--- a/source/introduction/what-is-ethereum.rst
+++ b/source/introduction/what-is-ethereum.rst
@@ -62,7 +62,7 @@ Learn about Ethereum
 PR videos with some pathos:
 ---------------------------------
 
-* `Ethereum: the World Computer <https://www.youtube.com/watch?v=j23HnORQXvs>`_
+* `Ethereum: the World Computer <https://www.youtube.com/watch?v=j23HnORQXvs>_
 * `Ethereum -- your turn <https://vimeo.com/88959651>`_
 
 


### PR DESCRIPTION
Travis should fail on this commit since there is a single build warning. If it does, I will push a commit that fixes the warning.

There is probably a better way to achieve this, i.e. through the warning-is-error tag mentioned [here](http://www.sphinx-doc.org/en/stable/setuptools.html), but I am out of my depth when it comes to Sphinx and am not sure how to set it up to run that way.