### PR TITLE
readthedocs.org build fix

### DIFF
--- a/old-docs-for-reference/go-ethereum-wiki.rst/Sending-ether.rst
+++ b/old-docs-for-reference/go-ethereum-wiki.rst/Sending-ether.rst
@@ -4,14 +4,14 @@ Sending ether
 The basic way of sending a simple transaction of ether using the console
 is as follows:
 
-.. code:: JavaScript
+.. code:: javascript
 
     > eth.sendTransaction({from:sender, to:receiver, value: amount})
 
 Using the built-in JavaScript, you can easily set variables to hold
 these values. For example:
 
-.. code:: JavaScript
+.. code:: javascript
 
     > var sender = eth.accounts[0];
     > var receiver = eth.accounts[1];
@@ -19,7 +19,7 @@ these values. For example:
 
 Alternatively, you can compose a transaction in a single line with:
 
-.. code:: JavaScript
+.. code:: javascript
 
     > eth.sendTransaction({from:eth.coinbase, to:eth.accounts[1], value: web3.toWei(0.05, "ether")})
     Please unlock account d1ade25ccd3d550a7eb532ac759cac7be09c2719.
@@ -32,7 +32,7 @@ The resulting transaction is
 
 If the password was incorrect you will instead receive an error:
 
-.. code:: JavaScript
+.. code:: javascript
 
     error: could not unlock sender account
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-restructuredtext-lint==0.14.2
+restructuredtext-lint==1.1.3
 Pigments==1.6
-Sphinx==1.3.6
+sphinx-rtd-theme==0.2.4
+Sphinx==1.7.1

--- a/source/account-management.rst
+++ b/source/account-management.rst
@@ -50,7 +50,7 @@ Once you have the geth client installed, creating an account is merely a case of
 
 Note that you do not have to run the geth client or sync up with the blockchain to use the ``geth account`` command.
 
-.. code-block:: Bash
+.. code-block:: bash
 
   $ geth account new
 
@@ -61,13 +61,13 @@ Note that you do not have to run the geth client or sync up with the blockchain 
 
 For non-interactive use you supply a plaintext password file as argument to the ``--password`` flag. The data in the file consists of the raw bytes of the password optionally followed by a single newline.
 
-.. code-block:: Bash
+.. code-block:: bash
 
   $ geth --password /path/to/password account new
 
 ..  Warning:: The ``--password`` flag is meant to be used only for testing or automation in trusted environments. It is a bad idea to save your password to file or expose it in any other way. If you do use the ``--password`` flag with a password file, make sure the file is not readable or even listable for anyone but you. You can achieve this in Mac/Linux systems with:
 
-.. code-block:: Bash
+.. code-block:: bash
 
   touch /path/to/password
   chmod 600 /path/to/password
@@ -77,7 +77,7 @@ For non-interactive use you supply a plaintext password file as argument to the 
 
 To list all the accounts with keyfiles currently in your ``keystore`` folder use the ``list`` subcommand of the ``geth account`` command:
 
-.. code-block:: Bash
+.. code-block:: bash
 
   $ geth account list
 
@@ -94,7 +94,7 @@ Using geth console
 
 In order to create a new account using geth, we must first start geth in console mode (or you can use ``geth attach`` to attach a console to an already running instance):
 
-.. code-block:: Bash
+.. code-block:: bash
 
   > geth console 2>> file_to_log_output
   instance: Geth/v1.4.0-unstable/linux/go1.5.1
@@ -104,7 +104,7 @@ In order to create a new account using geth, we must first start geth in console
 
 The console allows you to interact with your local node by issuing commands. For example, try the command to list your accounts:
 
-.. code-block:: Javascript
+.. code-block:: javascript
 
   > eth.accounts
 
@@ -115,7 +115,7 @@ The console allows you to interact with your local node by issuing commands. For
 
 This shows that you have no accounts. You can also create an account from the console:
 
-.. code-block:: Javascript
+.. code-block:: javascript
 
   > personal.newAccount()
   Passphrase:
@@ -126,7 +126,7 @@ This shows that you have no accounts. You can also create an account from the co
 
 We just created our first account. If we try to list our accounts again we can see our new account:
 
-.. code-block:: Javascript
+.. code-block:: javascript
 
   > eth.accounts
   ["0xb2f69ddf70297958e582a0cc98bce43294f1007d"]
@@ -213,7 +213,7 @@ Every option related to key management available using geth can be used the same
 
 Below are "account" related options:
 
-.. code-block:: Javascript
+.. code-block:: javascript
 
   > eth account list  // List all keys available in wallet.
   > eth account new   // Create a new key and add it to the wallet.
@@ -222,7 +222,7 @@ Below are "account" related options:
 
 Below are "wallet" related option:
 
-.. code-block:: Javascript
+.. code-block:: javascript
 
   > eth wallet import <file> //Import a presale wallet.
 
@@ -230,7 +230,7 @@ Below are "wallet" related option:
 
 It is also possible to access keys management from the integrated console (using the built-in console or geth attach):
 
-.. code-block:: Javascript
+.. code-block:: javascript
 
   > web3.personal
   {
@@ -250,7 +250,7 @@ Ethkey is a CLI tool of the C++ implementation that allows you to interact with 
 We will assume you have not yet run a client such as eth or anything in the Aleth series of clients. If you have, you can skip this section.
 To create a wallet, run ``ethkey`` with the ``createwallet`` command:
 
-.. code-block:: Bash
+.. code-block:: bash
 
   > ethkey createwallet
 
@@ -261,7 +261,7 @@ You'll be asked for a "master" passphrase. This protects your privacy and acts a
 
 We can list the keys within the wallet simply by using the list command:
 
-.. code-block:: Bash
+.. code-block:: bash
 
   > ethkey list
 
@@ -271,7 +271,7 @@ We haven't yet created any keys, and it's telling us so! Let's create one.
 
 To create a key, we use the ``new`` command. To use it we must pass a name - this is the name we'll give to this account in the wallet. Let's call it "test":
 
-.. code-block:: Bash
+.. code-block:: bash
 
   > ethkey new test
 
@@ -282,7 +282,7 @@ Here, let's give it the incredibly imaginative passphrase of 123. (Never ever us
 Once you enter a passphrase, it'll ask you to confirm it by entering again. Enter 123 a second time.
 Because you gave it its own passphrase, it'll also ask you to provide a hint for this password which will be displayed to you whenever it asks you to enter it. The hint is stored in the wallet and is itself protected by the master passphrase. Enter the truly awful hint of 321 backwards.
 
-.. code-block:: Bash
+.. code-block:: bash
 
   > ethkey new test
 
@@ -298,7 +298,7 @@ Because you gave it its own passphrase, it'll also ask you to provide a hint for
 All normal (aka direct) ICAP addresses begin with XE so you should be able to recognize them easily. Notice also that the key has another identifier after Created key. This is known as the UUID. This is a unique identifier for the key that has absolutely nothing to do with the account itself. Knowing it does nothing to help an attacker discover who you are on the network. It also happens to be the filename for the key, which you can find in either ~/.web3/keys (Mac or Linux) or $HOME/AppData/Web3/keys (Windows).
 Now let's make sure it worked properly by listing the keys in the wallet:
 
-.. code-block:: Bash
+.. code-block:: bash
 
   > ethkey list
   055dde03-47ff-dded-8950-0fe39b1fa101 0092e965… XE472EVKU3CGMJF2YQ0J9RO1Y90BC0LDFZ  test
@@ -336,7 +336,7 @@ Using geth
 
 If you have a standalone installation of geth, importing your presale wallet is accomplished by executing the following command in a terminal:
 
-.. code-block:: Bash
+.. code-block:: bash
 
   geth wallet import /path/to/my/presale-wallet.json
 
@@ -352,19 +352,19 @@ Using geth
 
 You can update an existing account on the command line with the ``update`` subcommand with the account address or index as parameter. Remember that the account index reflects the order of creation (lexicographic order of keyfile names containing the creation time).
 
-.. code-block:: Bash
+.. code-block:: bash
 
   geth account update b0047c606f3af7392e073ed13253f8f4710b08b6
 
 or
 
-.. code-block:: Bash
+.. code-block:: bash
 
   geth account update 2
 
 For example:
 
-.. code-block:: Bash
+.. code-block:: bash
 
   $ geth account update a94f5374fce5edbc8e2a8697c15331677e6ebf0b
 
@@ -381,7 +381,7 @@ The account is saved in the newest version in encrypted format, you are prompted
 
 For non-interactive use the passphrase can be specified with the ``--password`` flag:
 
-.. code-block:: Bash
+.. code-block:: bash
 
   geth --password <passwordfile> account update a94f5374fce5edbc8e2a8697c15331677e6ebf0bs
 
@@ -413,7 +413,7 @@ Importing an unencrypted private key
 
 Importing an unencrypted private key is supported by ``geth``
 
-.. code-block:: Bash
+.. code-block:: bash
 
   geth account import /path/to/<keyfile>
 
@@ -423,7 +423,7 @@ The account is saved in encrypted format, you are prompted for a passphrase. You
 
 An example where the data directory is specified. If the ``--datadir`` flag is not used, the new account will be created in the default data directory, i.e., the keyfile will be placed in the ``keystore`` subdirectory of the data directory.
 
-.. code-block:: Bash
+.. code-block:: bash
 
   $ geth --datadir /someOtherEthDataDir  account import ./key.prv
   The new account will be encrypted with a passphrase.
@@ -434,7 +434,7 @@ An example where the data directory is specified. If the ``--datadir`` flag is n
 
 For non-interactive use the passphrase can be specified with the ``--password`` flag:
 
-.. code-block:: Bash
+.. code-block:: bash
 
   geth --password <passwordfile> account import <keyfile>
 

--- a/source/contracts-and-transactions/developer-tools.rst
+++ b/source/contracts-and-transactions/developer-tools.rst
@@ -122,20 +122,20 @@ To use this console you would need to start a local ethereum node with ipc commu
 By default ipc socket should be located at your local home directory in .ethereum after you started a node.
 You could also set ``--test`` option to use specific node test commands.
 
-.. code:: Console
+.. code:: console
 
    > eth --test
    > ethconsole ipc://path/to/geth.ipc
 
 In the console you could then type
 
-.. code:: Console
+.. code:: console
 
    > web3.eth.<command name> (arguments, function(){})
 
 Here the defenition of ``--test`` mode node commands:
 
-.. code:: Console
+.. code:: console
 
    > web3.test.addBlock("[RLP]", function(){}) - Add a block from a string containing its hex RLP
    > web3.test.rewindToBlock:("[int]", function(){}) - Reset the blockchain to specified block number

--- a/source/ethereum-clients/cpp-ethereum/running.rst
+++ b/source/ethereum-clients/cpp-ethereum/running.rst
@@ -11,7 +11,7 @@ Interacting with your node can be done using either geth or the ethereum console
 
 **Using geth**
 
-.. code:: Console
+.. code:: console
 
    > geth attach //attach geth to a running eth node.
 

--- a/source/mining.rst
+++ b/source/mining.rst
@@ -98,7 +98,7 @@ The ``-minerthreads`` parameter can be used to set the number parallel mining th
 
 You can also start and stop CPU mining at runtime using the `console <https://github.com/ethereum/go-ethereum/wiki/JavaScript-Console#adminminerstart>`__. ``miner.start`` takes an optional parameter for the number of miner threads.
 
-.. code-block:: Javascript
+.. code-block:: javascript
 
     > miner.start(8)
     true
@@ -126,20 +126,21 @@ Note that your etherbase does not need to be an address of a local account, just
 
 There is an option `to add extra Data <https://github.com/ethereum/go-ethereum/wiki/JavaScript-Console#minersetextra>`__ (32 bytes only) to your mined blocks. By convention this is interpreted as a unicode string, so you can set your short vanity tag.
 
-.. code-block:: javascript
+.. code-block:: none
 
-    miner.setExtra("ΞTHΞЯSPHΞЯΞ")
+    > miner.setExtra("ΞTHΞЯSPHΞЯΞ")
     ...
-    debug.printBlock(131805)
+    > debug.printBlock(131805)
     BLOCK(be465b020fdbedc4063756f0912b5a89bbb4735bd1d1df84363e05ade0195cb1): Size: 531.00 B TD: 643485290485 {
     NoNonce: ee48752c3a0bfe3d85339451a5f3f411c21c8170353e450985e1faab0a9ac4cc
     Header:
-    [
-    ...
+        [
+        ...
             Coinbase:           a4d8e9cae4d04b093aac82e6cd355b6b963fb7ff
             Number:             131805
             Extra:              ΞTHΞЯSPHΞЯΞ
-    ...
+        ...
+        ]
     }
 
 You can check your hashrate with `miner.hashrate <https://github.com/ethereum/go-ethereum/wiki/JavaScript-Console#adminminerhashrate>`_, the result is in H/s (Hash operations per second).

--- a/source/network/connecting-to-the-network.rst
+++ b/source/network/connecting-to-the-network.rst
@@ -48,7 +48,7 @@ Checking connectivity and ENODE IDs
 
 To check how many peers the client is connected to in the interactive console, the ``net`` module has two attributes that give you info about the number of peers and whether you are a listening node.
 
-.. code-block:: Javascript
+.. code-block:: javascript
 
   > net.listening
   true
@@ -58,7 +58,7 @@ To check how many peers the client is connected to in the interactive console, t
 
 To get more information about the connected peers, such as IP address and port number, supported protocols, use the ``peers()`` function of the ``admin`` object. ``admin.peers()`` returns the list of currently connected peers.
 
-.. code-block:: Javascript
+.. code-block:: javascript
 
   > admin.peers
   [{
@@ -90,7 +90,7 @@ To get more information about the connected peers, such as IP address and port n
 
 To check the ports used by geth and also find your enode URI run:
 
-.. code-block:: Javascript
+.. code-block:: javascript
 
   > admin.nodeInfo
   {
@@ -135,7 +135,7 @@ This flag enables the JIT VM.
 
 Full example command with console:
 
-.. code-block:: Bash
+.. code-block:: bash
 
   geth --fast --cache=1024 --jitvm console
 
@@ -153,7 +153,7 @@ Static Nodes, Trusted Nodes, and Boot Nodes
 
 Geth supports a feature called static nodes if you have certain peers you always want to connect to. Static nodes are re-connected on disconnects. You can configure permanent static nodes by putting something like the following into ``<datadir>/static-nodes.json`` (this should be the same folder that your ``chaindata`` and ``keystore`` folders are in)
 
-.. code-block:: Javascript
+.. code-block:: javascript
 
   [
   	"enode://f4642fa65af50cfdea8fa7414a5def7bb7991478b768e296f5e4a54e8b995de102e0ceae2e826f293c481b5325f89be6d207b003382e18a8ecba66fbaf6416c0@33.4.2.1:30303",
@@ -162,7 +162,7 @@ Geth supports a feature called static nodes if you have certain peers you always
 
 You can also add static nodes at runtime via the Javascript console using ``admin.addPeer()``
 
-.. code-block:: Console
+.. code-block:: console
 
   > admin.addPeer("enode://f4642fa65af50cfdea8fa7414a5def7bb7991478b768e296f5e4a54e8b995de102e0ceae2e826f293c481b5325f89be6d207b003382e18a8ecba66fbaf6416c0@33.4.2.1:30303")
 

--- a/source/network/test-networks.rst
+++ b/source/network/test-networks.rst
@@ -17,7 +17,7 @@ eth (C++ client)
 
 This is supported natively on 0.9.93 and above. Pass the ``--ropsten`` argument in when starting any of the clients. e.g.:
 
-.. code:: Console
+.. code:: console
 
    > eth --ropsten
 
@@ -26,14 +26,14 @@ PyEthApp (Python client)
 
 PyEthApp currently only supports the old morden testnet. From v1.0.5 onwards:
 
-.. code:: Console
+.. code:: console
 
    > pyethapp --profile morden run
 
 geth (Go client)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code:: Console
+.. code:: console
 
    > geth --testnet
 
@@ -72,7 +72,7 @@ eth (C++ client)
 
 It is possible to connect to or create a new network by using the --genesis and --config.
 
-.. code:: Console
+.. code:: console
 
   > eth --private "customChain" --config config.json --genesis genesis.json
 
@@ -80,11 +80,11 @@ It is possible to use both --config and --genesis.
 
 In that case, the genesis block description provided by --config will be overwritten by the --genesis option.
 
-.. code:: Console
+.. code:: console
 
   --private //defines the name of the custom chain (optional).
 
-.. code:: Console
+.. code:: console
 
   --config <filename>
 
@@ -104,7 +104,7 @@ In that case, the genesis block description provided by --config will be overwri
 
 Here is a Config sample (used by the Olympic network):
 
-.. code:: JSON
+.. code:: json
 
     {
     	"sealEngine": "Ethash",
@@ -149,7 +149,7 @@ Here is a Config sample (used by the Olympic network):
     }
 
 
-.. code:: Console
+.. code:: console
 
   --genesis <filename> (optional if the config option is provided and contains the genesis description).
 
@@ -157,7 +157,7 @@ Here is a Config sample (used by the Olympic network):
 
 The content is the same as the genesis field provided by the 'config' parameter:
 
-.. code:: JavaScript
+.. code:: javascript
 
   {
 		"nonce": "0x000000000000002a",
@@ -197,7 +197,7 @@ blockchain unless they have the same genesis block, so you can make as many priv
 
 :file:`CustomGenesis.json`
 
-.. code-block:: JSON
+.. code-block:: json
 
   {
       "config": { }, "nonce": "0x0000000000000042",     "timestamp": "0x0",
@@ -267,7 +267,7 @@ Launching ``geth``
 
 After you have created your custom genesis block JSON file and created a directory for your blockchain data, type the following command into your console that has access to geth:
 
-.. code-block:: Console
+.. code-block:: console
 
   geth --identity "MyNodeName" --rpc --rpcport "8080" --rpccorsdomain "*" --datadir "C:\chains\TestChain1" --port "30303" --nodiscover --rpcapi "db,eth,net,web3" --networkid 1999 init /path/to/CustomGenesis.json
 
@@ -275,7 +275,7 @@ After you have created your custom genesis block JSON file and created a directo
 
 This will initialize your genesis block.  To interact with geth through the console enter: 
 
-.. code-block:: Console
+.. code-block:: console
 
   geth --identity "MyNodeName" --rpc --rpcport "8080" --rpccorsdomain "*" --datadir "C:\chains\TestChain1" --port "30303" --nodiscover --rpcapi "db,eth,net,web3" --networkid 1999 console
 
@@ -285,7 +285,7 @@ The full list of methods available through the javascript console is available o
 
 If you already have a geth node running, you can attach another geth instance to it using:
 
-.. code-block:: Console
+.. code-block:: console
 
   geth attach
 
@@ -293,7 +293,7 @@ Now you'll need to initialize a new account on the testnest, and set it as your 
 
 In the javascript console type
 
-.. code-block:: Console
+.. code-block:: console
 
   personal.newAccount("password")
 
@@ -301,7 +301,7 @@ In the javascript console type
 
 Now we'll set it as the etherbase:
 
-.. code-block:: Console
+.. code-block:: console
 
   miner.setEtherbase(personal.listAccounts[0])
 
@@ -309,7 +309,7 @@ If successful, the console will print "true"
 
 Finally, you are ready to start mining test ether:
 
-.. code-block:: Console
+.. code-block:: console
 
   miner.start()
 
@@ -322,7 +322,7 @@ A difficulty of "0x400" allows you to mine Ether very quickly on your private te
 2. Copy your new account address
 3. Add the following command to your Custom_Genesis.json file:
 
-.. code-block:: Javascript
+.. code-block:: javascript
 
   "alloc":
   {
@@ -338,7 +338,7 @@ We want to assign an address to the variable ``primary`` and check its balance.
 
 Run the command ``geth account list`` in your terminal to see what account # your new address was assigned.
 
-.. code-block:: Console
+.. code-block:: console
 
    > geth account list
    Account #0: {d1ade25ccd3d550a7eb532ac759cac7be09c2719}
@@ -349,13 +349,13 @@ Run the command ``geth account list`` in your terminal to see what account # you
 Take note of which account # is the one that you pre-allocated ether to.
 Alternatively, you can launch the console with ``geth console`` (keep the same parameters as when you launched ``geth`` first). Once the prompt appears, type
 
-.. code-block:: Console
+.. code-block:: console
 
   > eth.accounts
 
 This will return the array of account addresses you possess.
 
-.. code-block:: Console
+.. code-block:: console
 
   > primary = eth.accounts[0]
 
@@ -363,7 +363,7 @@ This will return the array of account addresses you possess.
 
 Type the following command:
 
-.. code-block:: Console
+.. code-block:: console
 
   > balance = web3.fromWei(eth.getBalance(primary), "ether");
 


### PR DESCRIPTION
This is a potential fix for #389 which appears to be caused by [this Sphinx issue](https://github.com/sphinx-doc/sphinx/issues/3212). I can't verify it without running the actual build on Read the Docs, but the problem should go away if the build uses a new Sphinx version.

Note that [wiping the environment](http://docs.readthedocs.io/en/latest/guides/wipe-environment.html) on readthedocs.org may be required.

The second commit fixes a bunch of Pygments lexer errors that showed up after the upgrade.