### PR TITLE
fix wrong address derivation instruction

### DIFF
--- a/source/account-management.rst
+++ b/source/account-management.rst
@@ -17,7 +17,7 @@ Accounts represent identities of external agents (e.g., human personas, mining n
 Keyfiles
 ================================================================================
 
-Every account is defined by a pair of keys, a private key and public key. Accounts are indexed by their *address* which is derived from the public key by taking the last 20 bytes. Every private key/address pair is encoded in a *keyfile*. Keyfiles are JSON text files which you can open and view in any text editor. The critical component of the keyfile, your account’s private key, is always encrypted, and it is encrypted with the password you enter when you create the account. Keyfiles are found in the ``keystore`` subdirectory of your Ethereum node’s data directory. Make sure you backup your keyfiles regularly! See the section :ref:`backup-and-restore-accounts` for more information.
+Every account is defined by a pair of keys, a private key and public key. Accounts are indexed by their *address* which is derived from the public key by hashing it as hexadecimal input of the keccak-256 hashfunction and taking the last 20 bytes of the result. Every private key/address pair is encoded in a *keyfile*. Keyfiles are JSON text files which you can open and view in any text editor. The critical component of the keyfile, your account’s private key, is always encrypted, and it is encrypted with the password you enter when you create the account. Keyfiles are found in the ``keystore`` subdirectory of your Ethereum node’s data directory. Make sure you backup your keyfiles regularly! See the section :ref:`backup-and-restore-accounts` for more information.
 
 Creating a key is tantamount to creating an account.
 


### PR DESCRIPTION
It's not the last 20 bytes of the public key, it's the last 20 bytes of the hash of the public key.

Credits: https://kobl.one/blog/create-full-ethereum-keypair-and-address/#complete-example