### PR TITLE
Update macOS guide to be more current

### DIFF
--- a/source/ethereum-clients/cpp-ethereum/building-from-source/macos.rst
+++ b/source/ethereum-clients/cpp-ethereum/building-from-source/macos.rst
@@ -1,11 +1,11 @@
 
-Building for OS X
+Building for macOS
 ================================================================================
 
 Overview - Here be dragons!
 --------------------------------------------------------------------------------
 
-It is impossible for us to avoid OS X build breaks because `Homebrew is a "rolling
+It is impossible for us to avoid macOS build breaks because `Homebrew is a "rolling
 release" package manager
 <https://github.com/ethereum/webthree-umbrella/issues/118>`_
 which means that the ground will forever be moving underneath us unless we add
@@ -16,28 +16,24 @@ on when they are build the project.  Building yesterday may have worked for
 you, but that doesn't guarantee that your friend will have the same result
 today on their machine.   Needless to say, this isn't a happy situation.
 
-If you hit build breaks for OS X please look through the `Github issues
+If you hit build breaks for macOS please look through the `Github issues
 <https://github.com/ethereum/cpp-ethereum/issues>`_ to see whether the
 issue you are experiencing has already been reported.   If so, please comment
 on that existing issue.  If you don't see anything which looks similar,
-please create a new issue, detailing your OS X version, cpp-ethereum version,
+please create a new issue, detailing your macOS version, cpp-ethereum version,
 hardware and any other details you think might be relevant.   Please add
 verbose log files via `gist.github.com <http://gist.github.com>`_ or a
 similar service.
 
-The `cpp-ethereum-development 
+The `cpp-ethereum-development
 <https://gitter.im/ethereum/cpp-ethereum-development>`_ gitter channel is where we hang out, and try
 to work together to get known issues resolved.
 
-We only support the following OS X versions:
+We support macOS versions above 10.9 (Mavericks)
 
-- `OS X Mavericks (10.9) <https://en.wikipedia.org/wiki/OS_X_Mavericks>`_
-- `OS X Yosemite (10.10) <https://en.wikipedia.org/wiki/OS_X_Yosemite>`_
-- `OS X El Capitan (10.11) <https://en.wikipedia.org/wiki/OS_X_El_Capitan>`_
-
-The cpp-ethereum code base does not build on older OS X versions and this
+The cpp-ethereum code base does not build on older macOS versions and this
 is not something which we will ever support.  If you are using an older
-OS X version, we recommend that you update to the latest release, not
+macOS version, we recommend that you update to the latest release, not
 just so that you can build cpp-ethereum, but for your own security.
 
 
@@ -57,21 +53,20 @@ Ensure that you have the latest version of
 `xcode installed <https://developer.apple.com/xcode/download/>`_.
 This contains the `Clang C++ compiler <https://en.wikipedia.org/wiki/Clang>`_, the
 `xcode IDE <https://en.wikipedia.org/wiki/Xcode>`_ and other Apple development
-tools which are required for building C++ applications on OS X.
+tools which are required for building C++ applications on macOS.
 If you are installing xcode for the first time, or have just installed a new
 version then you will need to agree to the license before you can do
 command-line builds: ::
 
     sudo xcodebuild -license accept
 
-Our OS X builds require you to `install the Homebrew <http://brew.sh>`_
+Our macOS builds require you to `install the Homebrew <http://brew.sh>`_
 package manager for installing external dependencies.
 Here's how to `uninstall Homebrew
 <https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/FAQ.md#how-do-i-uninstall-homebrew>`_,
 if you ever want to start again from scratch.
 
-We now have a "one button" script which installs all required external dependencies
-on macOS and on numerous Linux distros.   This used to a multi-step manual process: ::
+We have a script which installs all required external dependencies on macOS and on Linux distros.: ::
 
     ./scripts/install_deps.sh
 
@@ -94,10 +89,10 @@ You can also use the same Makefile to install your own build globally on your ma
 
     make install
 
-This will install binaries into **/usr/local/** and **/usr/bin/**.
+This installs binaries into **/usr/local/** and **/usr/bin/**.
 
 
-Generate xcode project
+Generate Xcode project
 --------------------------------------------------------------------------------
 
 From the project root: ::
@@ -106,5 +101,5 @@ From the project root: ::
     cd build_xc
     cmake -G Xcode ..
 
-This will generate an Xcode project file called **cpp-ethereum.xcodeproj**,
-which you can then open with xcode and build/debug/run.
+This generates an Xcode project file called **cpp-ethereum.xcodeproj**,
+which you can then open with Xcodes and build/debug/run.


### PR DESCRIPTION
Update mac build pages with newer versions, use latest branding and add support for newer macOS versions.